### PR TITLE
Fixing background color on .site-head

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -177,7 +177,7 @@ function casper_customizer_head() {
         	}
         <?php } ?>
 		<?php if(get_theme_mod('casper_header_color')){ ?>
-		    .site-head { background-color: <?php echo get_theme_mod( 'casper_header_color' ); ?>; }
+		    .site-head { background-color: #<?php echo get_theme_mod( 'casper_header_color' ); ?>; }
 		<?php } ?>
         <?php if(false != get_theme_mod( 'casper_display_header' )) { ?>
         	body:not(.home) #masthead{ background: none; }


### PR DESCRIPTION
Missing a # prefix for hex code on .site-head background-color 